### PR TITLE
Fix 'undefined reference' errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS=-Wall -lcurses
 OBJ=2048_game.c
 
 all:
-	$(CC) $(CFLAGS) $(OBJ) -o 2048
+	$(CC) $(OBJ) $(CFLAGS) -o 2048
 
 clean:
 	rm -f 2048


### PR DESCRIPTION
When attempting to compile the application I received a number of 'undefined reference' errors. Placing the -lcurses option after the object files (from [here](http://stackoverflow.com/a/17072387)) in the call to gcc allowed for successful compilation. I've edited the Makefile accordingly.
